### PR TITLE
Add certificate filename in haproxy.cfg

### DIFF
--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -13,7 +13,7 @@ frontend http
   redirect scheme https code 301
 
 frontend https
-  bind *:443 ssl crt /certs
+  bind *:443 ssl crt /certs/certificate.pem
   default_backend foodsoft
 
   http-response set-header Strict-Transport-Security "max-age=16000000;"


### PR DESCRIPTION
Is it correct that one has to specify some filename here? I had to change this line to get it running.