### PR TITLE
[WiP] SSL certificates + letsencrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,64 @@
 Foodcoops.net deployment demo
 =============================
 
-You need to create a certificate for your setup before you can start. For testing purpose only you can add it via `COPY` in `haproxy/Dockerfile` or you mount it via an volume in the `docker-compose.yml`. Check out the comments the files.
+You need to create a certificate for your setup before you can start. For testing purpose only you can add it via `COPY` in `haproxy/Dockerfile` or you mount it via an volume in the `docker-compose.yml`. Check out the comments the files (also see [section below](#Generating_test_certificates)).
 
 To get it running you need to provide the private information via environment variables to `docker-compose`. Here is an example to build and start the project:
 
 ```shell
 export FOODSOFT_DB_PASSWORD=foodsoft
-export FOODSOFT_SECRET_KEY_BASE=secret
+export FOODSOFT_SECRET_KEY_BASE=secret_fs
+export SHAREDLISTS_DB_PASSWORD=sharedlists
+export SHAREDLISTS_SECRET_KEY_BASE=secret_sl
 export MYSQL_ROOT_PASSWORD=mysql
+
 docker-compose build --pull
 docker-compose up -d
 ```
+
+## Initial database setup
+
+On first time run, you'll need to setup the database. Start and connect to it as root:
+
+```shell
+docker-compose up -d mariadb redis
+docker inspect foodcoopsnet_mariadb_1 | grep '"IPAddress"'
+# "IPAddress": "172.20.0.2",
+mysql -h 172.20.0.2 -u root -p
+```
+
+Then run the following SQL commands:
+
+```sql
+CREATE DATABASE foodsoft CHARACTER SET utf8 COLLATE utf8_bin;
+GRANT ALL ON foodsoft.* TO foodsoft@'%' IDENTIFIED BY 'secret_fs';
+
+CREATE DATABASE sharedlists CHARACTER SET utf8 COLLATE utf8_bin;
+GRANT ALL ON sharedlists.* TO sharedlists@'%' IDENTIFIED BY 'secret_sl';
+GRANT SELECT ON sharedlists.* TO foodsoft@'%';
+```
+
+Finally you need to populate the databases:
+
+```shell
+docker-compose run --rm foodsoft_web bundle exec rake db:setup
+docker-compose run --rm sharedlists_web bundle exec rake db:setup
+```
+
+
+## Generating test certificates
+
+To get started, you might want to generate test certificates.
+
+```shell
+cd haproxy
+openssl genrsa -out cert.key 2048
+openssl req -new -key cert.key -out cert.csr
+# for "Common Name" specify e.g. localhost
+openssl x509 -req -days 3650 -in cert.csr -signkey cert.key -out cert.crt
+cat cert.key cert.crt >certificate.pem
+```
+
+Uncomment the line in `haproxy/Dockerfile` that copies this, and (re-)run `docker-compose build`.
+
+Now you're ready to run `docker-compose up` for the first time.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Foodcoops.net deployment demo
 =============================
 
-You need to create a certificate for your setup before you can start. For testing purpose only you can add it via `COPY` in `haproxy/Dockerfile` or you mount it via an volume in the `docker-compose.yml`. Check out the comments the files (also see [section below](#Generating_test_certificates)).
-
 To get it running you need to provide the private information via environment variables to `docker-compose`. Here is an example to build and start the project:
 
 ```shell
@@ -46,19 +44,18 @@ docker-compose run --rm sharedlists_web bundle exec rake db:setup
 ```
 
 
-## Generating test certificates
+## SSL Certificates
 
-To get started, you might want to generate test certificates.
+_This section is a work in progress._
+
+On first startup, a dummy SSL certificate is generated. This is required to get everything
+going, and see if everything works. When all is ready, you can easily request a certificate
+from [letsencrypt](https://letsencrypt.org/).
 
 ```shell
-cd haproxy
-openssl genrsa -out cert.key 2048
-openssl req -new -key cert.key -out cert.csr
-# for "Common Name" specify e.g. localhost
-openssl x509 -req -days 3650 -in cert.csr -signkey cert.key -out cert.crt
-cat cert.key cert.crt >certificate.pem
+docker-compose run --rm acme --issue -d app.example.com --standalone --test \
+  --reloadcmd 'cat $CERT_KEY_PATH $CERT_FULLCHAIN_PATH >/acme.sh/certs/bundle.pem && touch /acme.sh/updated'
 ```
 
-Uncomment the line in `haproxy/Dockerfile` that copies this, and (re-)run `docker-compose build`.
-
-Now you're ready to run `docker-compose up` for the first time.
+Replace `app.example.com` with yours, and remove `--test` when you're confident it works.
+This will _almost_ work (since the one-off instance doesn't get http requests forwarded).

--- a/acme/Dockerfile
+++ b/acme/Dockerfile
@@ -1,0 +1,6 @@
+FROM neilpang/acme.sh
+
+EXPOSE 80
+
+COPY daemon.local /usr/local/bin/
+CMD ["/usr/local/bin/daemon.local"]

--- a/acme/daemon.local
+++ b/acme/daemon.local
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Run acme.sh daemon, and also create a dummy certificate for starting up
+#
+CERTS_DIR=/acme.sh/certs
+UPDATED_FILE=/acme.sh/updated
+
+has_certs() {
+  ls ${CERTS_DIR}/*.pem >/dev/null 2>&1
+}
+
+mkdir -p ${CERTS_DIR}
+
+# generate dummy ssl certificate if needed
+if ! has_certs; then
+  echo "WARNING: no certificates found, generating dummy"
+  openssl req -subj '/CN=localhost' -new -newkey rsa:2048 -days 365 -nodes -x509 \
+     -keyout ${CERTS_DIR}/dummy.key -out ${CERTS_DIR}/dummy.crt
+  cat ${CERTS_DIR}/dummy.key ${CERTS_DIR}/dummy.crt >${CERTS_DIR}/dummy.pem
+  rm -f ${CERTS_DIR}/dummy.key ${CERTS_DIR}/dummy.crt
+  touch ${UPDATED_FILE}
+fi
+
+/entry.sh daemon --standalone --reloadcmd "cat \$CERT_KEY_PATH \$CERT_FULLCHAIN_PATH >${CERTS_DIR}/bundle.pem && touch ${UPDATED_FILE}" $@

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,8 +53,14 @@ services:
     ports:
       - "80:80"
       - "443:443"
-    #volumes:
-    #  - certs:/certs:ro
+    volumes:
+      - certs:/certs:ro
+
+  acme:
+    build: acme
+    restart: always
+    volumes:
+      - certs:/acme.sh
 
   mariadb:
     image: mariadb:10.1
@@ -69,6 +75,6 @@ services:
     restart: always
 
 volumes:
-  #certs:
+  certs:
   mariadb:
   supplier_assets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,51 @@
 version: '2'
 services:
-  foodsoft:
+
+  #
+  # Foodsoft (main)
+  #
+
+  foodsoft_web:
     build: foodsoft
     restart: always
     environment:
-      - DATABASE_URL=mysql2://foodsoft:${FOODSOFT_DB_PASSWORD}@mariadb/foodsoft_test?encoding=utf8
+      - DATABASE_URL=mysql2://foodsoft:${FOODSOFT_DB_PASSWORD}@mariadb/foodsoft?encoding=utf8
+      - SHAREDLISTS_DATABASE_URL=mysql2://foodsoft:${FOODSOFT_DB_PASSWORD}@mariadb/sharedlists?encoding=utf8
       - QUEUE=foodsoft_notifier
       - REDIS_URL=redis://redis:6379
       - SECRET_KEY_BASE=${FOODSOFT_SECRET_KEY_BASE}
+      - RAILS_FORCE_SSL=false
 
   foodsoft_cron:
-    extends: foodsoft
-    command: cron -f
+    extends: foodsoft_web
+    command: ./proc-start cron
 
-  foodsoft_resque:
-    extends: foodsoft
-    command: rake resque:work
+  foodsoft_worker:
+    extends: foodsoft_web
+    command: ./proc-start worker
+
+  #
+  # Sharedlists
+  #
+
+  sharedlists_web:
+    image: foodcoops/sharedlists:latest
+    restart: always
+    environment:
+      - DATABASE_URL=mysql2://sharedlists:${SHAREDLISTS_DB_PASSWORD}@mariadb/sharedlists?encoding=utf8
+      - SECRET_TOKEN=${SHAREDLISTS_SECRET_KEY_BASE}
+      - RAILS_RELATIVE_URL_ROOT=/sharedlists
+      - RAILS_FORCE_SSL=false
+    volumes:
+      - supplier_assets:/usr/src/app/supplier_assets
+
+  sharedlists_cron:
+    extends: sharedlists_web
+    command: ./proc-start cron
+
+  #
+  # Supporting services
+  #
 
   haproxy:
     build: haproxy
@@ -23,14 +53,14 @@ services:
     ports:
       - "80:80"
       - "443:443"
-#    volumes:
-#      - certs:/certs:ro
+    #volumes:
+    #  - certs:/certs:ro
 
   mariadb:
     image: mariadb:10.1
     restart: always
     environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_ROOT_PASSWORD
     volumes:
       - mariadb:/var/lib/mysql
 
@@ -39,5 +69,6 @@ services:
     restart: always
 
 volumes:
-#  certs:
+  #certs:
   mariadb:
+  supplier_assets:

--- a/foodsoft/Dockerfile
+++ b/foodsoft/Dockerfile
@@ -1,3 +1,3 @@
-FROM foodcoopsat/foodsoft
+FROM foodcoops/foodsoft:latest
 
 COPY app_config.yml ./config

--- a/foodsoft/app_config.yml
+++ b/foodsoft/app_config.yml
@@ -13,14 +13,14 @@ default: &defaults
   # foodcoop contact information (used for FAX messages)
   contact:
     street: Grüne Straße 103
-    zip_code: "10997"
-    city: Berlin
-    country: Deutschland
+    zip_code: "10101"
+    city: Greencity
+    country: Foodland
     email: foodsoft@foodcoop.test
-    phone: "030 323 23249"
+    phone:
 
   # Homepage
-  homepage: http://www.foodcoop.test
+  homepage: https://foodcoops.github.io
 
   # foodsoft documentation URL
   help_url: https://github.com/foodcoops/foodsoft/wiki/Doku
@@ -29,7 +29,7 @@ default: &defaults
   applepear_url: https://github.com/foodcoops/foodsoft/wiki/%C3%84pfel-u.-Birnen
 
   # custom foodsoft software URL (used in footer)
-  #foodsoft_url: https://github.com/foodcoops/foodsoft
+  foodsoft_url: https://foodcoops.github.io
 
   # Default language
   #default_locale: en
@@ -125,8 +125,8 @@ default: &defaults
 
   # Config for the exception_notification plugin
   notification:
-    error_recipients:
-      - admin@foodcoop.test
+    #error_recipients:
+    #  - admin@foodcoop.test
     sender_address: "\"Foodsoft Error\" <foodsoft@foodcoop.test>"
     email_prefix: "[Foodsoft]"
 
@@ -147,8 +147,9 @@ default: &defaults
   #  password:
   #  encoding: utf8
   #  socket: /opt/lampp/var/mysql/mysql.sock
-  # Instead of defining all details here, you can also point to an entry in database.yml.
-  #shared_lists: shared_lists
+  # Instead of defining all details here, you can also point to an entry in database.yml,
+  # or provide a database url.
+  shared_lists: <%= ENV['SHAREDLISTS_DATABASE_URL'] %>
 
 development:
   <<: *defaults

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,4 +1,6 @@
-FROM haproxy:1.7
+FROM haproxy:1.7-alpine
 
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
-#COPY certificate.pem /certs
+COPY start.sh trigger.sh /
+
+CMD ["/start.sh"]

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -14,11 +14,16 @@ frontend http
 
 frontend https
   bind *:443 ssl crt /certs
-  default_backend foodsoft
+
+  default_backend foodsoft_web
+  acl sharedlists_path path_beg /sharedlists
+  use_backend sharedlists_web if sharedlists_path
 
   http-response set-header Strict-Transport-Security "max-age=16000000;"
   option forwardfor
   reqadd X-Forwarded-Proto:\ https
 
-backend foodsoft
-  server foodsoft foodsoft:3000
+backend foodsoft_web
+  server foodsoft_web foodsoft_web:3000
+backend sharedlists_web
+  server sharedlists_web sharedlists_web:3000

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -10,16 +10,22 @@ global
 
 frontend http
   bind *:80
-  redirect scheme https code 301
+
+  acl acme_path path_beg -i /.well-known/acme-challenge
+  use_backend acme if acme_path
+
+  redirect scheme https code 301 unless acme_path
 
 frontend https
-  bind *:443 ssl crt /certs
+  bind *:443 ssl crt /certs/certs
 
   default_backend foodsoft_web
+
   acl sharedlists_path path_beg /sharedlists
   use_backend sharedlists_web if sharedlists_path
 
   http-response set-header Strict-Transport-Security "max-age=16000000;"
+  http-response set-header X-Frame-Options "DENY"
   option forwardfor
   reqadd X-Forwarded-Proto:\ https
 
@@ -27,3 +33,5 @@ backend foodsoft_web
   server foodsoft_web foodsoft_web:3000
 backend sharedlists_web
   server sharedlists_web sharedlists_web:3000
+backend acme
+  server acme acme:80

--- a/haproxy/start.sh
+++ b/haproxy/start.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Run HAProxy with soft reload on certificate files changes
+#
+UPDATED_FILE=/certs/updated
+HAPROXY_PID_FILE=/run/haproxy.pid
+UPTODATE_FILE=/tmp/uptodate
+
+haproxy_pid() {
+  cat ${HAPROXY_PID_FILE} 2>/dev/null
+}
+
+# wait for updated file to be there (or we have no certificates anyway)
+if [ ! -e ${UPDATED_FILE} ]; then
+  echo "WARNING: no certificate update file found, waiting for it to appear (by acme)"
+  while [ ! -e ${UPDATED_FILE} ]; do sleep 3; done
+fi
+
+# watch for certificate updates to reload
+inotifyd /trigger.sh ${UPDATED_FILE}:ec &
+
+while true; do
+  touch ${UPTODATE_FILE}
+
+  haproxy -sf `haproxy_pid` -p ${HAPROXY_PID_FILE} -D -f /usr/local/etc/haproxy/haproxy.cfg $@
+  # exit immidiately in case of any errors
+  if [[ $? != 0 ]]; then exit $?; fi
+
+  # wait until trigger file is gone
+  inotifyd - ${UPTODATE_FILE} >/dev/null
+
+  # avoid race
+  sleep 1
+done

--- a/haproxy/trigger.sh
+++ b/haproxy/trigger.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+# Notify start.sh that something has changed
+#
+UPTODATE_FILE=/tmp/uptodate
+
+rm -f ${UPTODATE_FILE}


### PR DESCRIPTION
This implements SSL certificates with letsencrypt (#1).
On start, a dummy certificate is generated. This is necessary for HAProxy to start at all, and useful for initial testing. [acme.sh](http://acme.sh/) is used as a simple letsencrypt client. A cronjob runs to auto-renew certificates. On renewal, HAProxy reloads automatically (that was some work to figure out - somehow SIGHUP with the systemd wrapper wasn't able to restart the process).

Maybe a little explanation of how haproxy's auto-reload works. The acme and haproxy instance have a shared volume (mounted in `/acme.sh` on acme and in `/certs` on haproxy). Acme does its thing, and as part of the finish-hook it touches a file. The haproxy container has a custom run script that runs haproxy as a daemon. In the background, it watches the file touched in acme, and if that happens, a new haproxy process is started in a way that slowly takes over the connections from the old process (this is a little bit more complex, as you'll see when reading the code).

Pending:
- [ ] Log to stdout
- [ ] Instructions on how to generate a new letsencrypt certificate
- [ ] Move reloadcmd to a common place (so it's not needed when issuing a new certificate manually)
- [ ] Test letsencrypt for real (haven't tested it on a public box)
- [ ] Improve termination (`docker-compose stop haproxy`) _(nice to have)_

Oh, please look at the last commit only.
Note that there is still some discussion whether this is the best approach.