### PR TITLE
Add Postfix for routing incoming email

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ To update Foodsoft to a new version:
 ```shell
 cd /home/deploy/foodcoops.net
 docker-compose run --rm foodsoft bundle exec rake multicoops:run TASK=db:migrate
-docker-compose restart foodsoft foodsoft_worker # foodsoft_mail
+docker-compose restart foodsoft foodsoft_worker foodsoft_smtp
 ```
 
 ### Adding a new foodcoop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,10 @@ services:
         ${DOMAIN},www.${DOMAIN}
         app.${DOMAIN}
       CERTBOT_EMAIL: admin@${DOMAIN}
-      CERTBOT_TOUCH_FILE: /haproxy_triggers/reload
+      CERTBOT_TOUCH_FILE: /triggers/reload-certs
     volumes:
       - certs:/certs
-      - haproxy_triggers:/haproxy_triggers
+      - triggers:/triggers
 
   foodsoft:
     build: foodsoft
@@ -52,13 +52,13 @@ services:
     build: haproxy
     restart: always
     environment:
-      - HAPROXY_RELOAD_FILE=/haproxy_triggers/reload
+      - HAPROXY_RELOAD_FILE=/triggers/reload-certs
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - certs:/certs:ro
-      - haproxy_triggers:/haproxy_triggers
+      - triggers:/triggers
 
   mariadb:
     image: mariadb:10.3
@@ -108,11 +108,15 @@ services:
     environment:
       - DOMAIN=app.${DOMAIN}
       - HOSTNAME=app.${DOMAIN}
+      - POSTFIX_RELOAD_FILE=/triggers/reload-certs
     ports:
       - "25:25"
+    volumes:
+      - certs:/certs:ro
+      - triggers:/triggers
 
 volumes:
   certs:
-  haproxy_triggers:
   mariadb:
   supplier_assets:
+  triggers:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - REDIS_URL=redis://redis:6379
       - SECRET_KEY_BASE=${FOODSOFT_SECRET_KEY_BASE}
       - SHAREDLISTS_DATABASE_URL=mysql2://foodsoft:${FOODSOFT_DB_PASSWORD}@mariadb/sharedlists?encoding=utf8mb4
+      - MAILER_PREFIX=foodsoft+
       - SMTP_DOMAIN=app.${DOMAIN}
       - SMTP_ADDRESS
       - SMTP_PORT
@@ -39,6 +40,13 @@ services:
   foodsoft_worker:
     extends: foodsoft
     command: ./proc-start worker
+
+  foodsoft_smtp:
+    extends: foodsoft
+    command: ./proc-start mail
+    environment:
+      - SMTP_SERVER_PORT=2525
+      - SMTP_SERVER_HOST=0.0.0.0
 
   haproxy:
     build: haproxy
@@ -78,12 +86,30 @@ services:
       - DATABASE_URL=mysql2://sharedlists:${SHAREDLISTS_DB_PASSWORD}@mariadb/sharedlists?encoding=utf8mb4
       - SECRET_TOKEN=${SHAREDLISTS_SECRET_KEY_BASE}
       - RAILS_RELATIVE_URL_ROOT=/sharedlists
+      - MAILER_DOMAIN=app.${DOMAIN}
+      - MAILER_PREFIX=sharedlists+
     volumes:
       - supplier_assets:/usr/src/app/supplier_assets
 
   sharedlists_cron:
     extends: sharedlists
     command: ./proc-start cron
+
+  sharedlists_smtp:
+    extends: sharedlists
+    command: ./proc-start mail
+    environment:
+      - SMTP_SERVER_PORT=2525
+      - SMTP_SERVER_HOST=0.0.0.0
+
+  smtp:
+    build: smtp
+    restart: always
+    environment:
+      - DOMAIN=app.${DOMAIN}
+      - HOSTNAME=app.${DOMAIN}
+    ports:
+      - "25:25"
 
 volumes:
   certs:

--- a/smtp/Dockerfile
+++ b/smtp/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.5
 
-RUN apk add --no-cache postfix rsyslog
+RUN apk add --no-cache postfix rsyslog ca-certificates && \
+    update-ca-certificates
 
 COPY rsyslog.conf /etc/
 COPY main.cf /etc/postfix/

--- a/smtp/Dockerfile
+++ b/smtp/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.5
+
+RUN apk add --no-cache postfix rsyslog
+
+COPY rsyslog.conf /etc/
+COPY main.cf /etc/postfix/
+
+CMD rm -f /var/run/rsyslogd.pid && \
+    /usr/sbin/postconf -e "mydomain=${DOMAIN}" && \
+    /usr/sbin/postconf -e "myhostname=${HOSTNAME}" && \
+    /usr/lib/postfix/master & \
+    /usr/sbin/rsyslogd -n

--- a/smtp/Dockerfile
+++ b/smtp/Dockerfile
@@ -4,9 +4,8 @@ RUN apk add --no-cache postfix rsyslog
 
 COPY rsyslog.conf /etc/
 COPY main.cf /etc/postfix/
+COPY docker-entrypoint.sh reload-postfix.sh /
 
-CMD rm -f /var/run/rsyslogd.pid && \
-    /usr/sbin/postconf -e "mydomain=${DOMAIN}" && \
-    /usr/sbin/postconf -e "myhostname=${HOSTNAME}" && \
-    /usr/lib/postfix/master & \
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD /usr/lib/postfix/master & \
     /usr/sbin/rsyslogd -n

--- a/smtp/docker-entrypoint.sh
+++ b/smtp/docker-entrypoint.sh
@@ -4,8 +4,20 @@ set -e
 /usr/sbin/postconf -e "mydomain=${DOMAIN}"
 /usr/sbin/postconf -e "myhostname=${HOSTNAME}"
 
+# figure out which certificate to use
+CERT_FILE=/certs/${HOSTNAME}.pem
+[ -r "$CERT_FILE" ] || CERT_FILE=/certs/dummy.pem
+[ -r "$CERT_FILE" ] || CERT_FILE=
+if [ "$CERT_FILE" ]; then
+  /usr/sbin/postconf -e "smtpd_tls_cert_file=${CERT_FILE}"
+else
+  /usr/sbin/postconf -X smtpd_tls_cert_file
+fi
+
+# make sure rsyslogd can be started (in case container gets re-used)
 rm -f /var/run/rsyslogd.pid
 
+# reload on trigger
 if [ -n "$POSTFIX_RELOAD_FILE" ]; then
 	echo "Watching $POSTFIX_RELOAD_FILE for reload requests"
 	[ -e "$POSTFIX_RELOAD_FILE" ] || touch "$POSTFIX_RELOAD_FILE"

--- a/smtp/docker-entrypoint.sh
+++ b/smtp/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+/usr/sbin/postconf -e "mydomain=${DOMAIN}"
+/usr/sbin/postconf -e "myhostname=${HOSTNAME}"
+
+rm -f /var/run/rsyslogd.pid
+
+if [ -n "$POSTFIX_RELOAD_FILE" ]; then
+	echo "Watching $POSTFIX_RELOAD_FILE for reload requests"
+	[ -e "$POSTFIX_RELOAD_FILE" ] || touch "$POSTFIX_RELOAD_FILE"
+	inotifyd "/reload-postfix.sh" "$POSTFIX_RELOAD_FILE:ec" &
+fi
+
+exec "$@"

--- a/smtp/main.cf
+++ b/smtp/main.cf
@@ -49,6 +49,12 @@ alias_maps =
 tls_high_cipherlist = EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA128-SHA:AES128-SHA
 tls_preempt_cipherlist = yes
 tls_ssl_options = NO_COMPRESSION
+smtpd_tls_CApath = /etc/ssl/certs/
+
+# Incoming TLS
+smtpd_tls_cert_file = # overridden by postconf
+smtpd_tls_key_file = $smtpd_tls_cert_file
+smtpd_tls_security_level = may
 
 # Outgoing TLS is more flexible because 1. not all receiving servers will
 # support TLS, 2. not all will have and up-to-date TLS stack.

--- a/smtp/main.cf
+++ b/smtp/main.cf
@@ -1,0 +1,80 @@
+#
+# Postfix configuration (forward-only)
+#
+# Inspired by
+#   https://github.com/Mailu/Mailu/blob/master/core/postfix/
+#   https://github.com/hokstadconsulting/docker-postfix/
+#   https://www.howtoforge.com/community/threads/62955/
+#
+
+# Main domain and hostname
+mydomain = example.test        # overridden by postconf
+myhostname = smtp.example.test # overridden by postconf
+myorigin = $mydomain
+
+# Queue location
+#
+# When messages are relayed, it's important to have the queue directory
+# at a standard place and put on a Docker volume, or else messages may
+# get lost across instance restarts. For now, we only forward, so it's
+# not yet necessary to configure this.
+#queue_directory = /queue
+
+# Message size limit
+message_size_limit = 50000000
+
+# Relayed networks
+mynetworks = 127.0.0.1/32 [::1]/128
+
+# Forward mydomain to downstream smtp servers and disable local delivery.
+mydestination = $mydomain
+transport_maps = inline:{
+    { foodsoft@$mydomain    = smtp:[foodsoft_smtp]:2525    },
+    { sharedlists@$mydomain = smtp:[sharedlists_smtp]:2525 }
+  }
+local_recipient_maps =
+local_transport = error: local delivery disabled
+
+# Recipient delimiter for extended addresses
+recipient_delimiter = +
+
+# Empty alias list to override the configuration variable and disable NIS
+alias_maps =
+
+#
+# TLS
+#
+
+# General TLS configuration
+tls_high_cipherlist = EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA128-SHA:AES128-SHA
+tls_preempt_cipherlist = yes
+tls_ssl_options = NO_COMPRESSION
+
+# Outgoing TLS is more flexible because 1. not all receiving servers will
+# support TLS, 2. not all will have and up-to-date TLS stack.
+smtp_tls_security_level = may
+smtp_tls_mandatory_protocols = !SSLv2,!SSLv3
+smtp_tls_protocols =!SSLv2,!SSLv3
+smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+
+#
+# Restrictions
+#
+
+# Delay all rejects until all information can be logged
+smtpd_delay_reject = yes
+
+# Restrictions for incoming SMTP, other restrictions are applied in master.cf
+smtpd_helo_required = yes
+disable_vrfy_command = yes
+
+smtpd_recipient_restrictions =
+  permit_mynetworks,
+  reject_non_fqdn_sender,
+  reject_unknown_sender_domain,
+  reject_unknown_recipient_domain,
+  reject_unverified_recipient,
+  permit
+
+unverified_recipient_reject_reason = address lookup failure
+

--- a/smtp/reload-postfix.sh
+++ b/smtp/reload-postfix.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+exec /usr/sbin/postfix reload

--- a/smtp/rsyslog.conf
+++ b/smtp/rsyslog.conf
@@ -1,0 +1,4 @@
+$ModLoad imuxsock
+$template noTimestampFormat,"%syslogtag%%msg%\n"
+$ActionFileDefaultTemplate noTimestampFormat
+*.*;auth,authpriv.none /dev/stdout


### PR DESCRIPTION
Implements #2.

Pending:
- [x] TLS
- [x] Auto-reload on certificate change
- [ ] (maybe later) Implement `MAILER_PREFIX` in Foodsoft (like in [sharedlists](https://github.com/foodcoops/sharedlists#email))