### PR TITLE
Harden SSL

### DIFF
--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -5,8 +5,12 @@ defaults
   mode http
 
 global
-  ssl-default-bind-ciphers DEFAULT:!EXPORT:!RC4
-  tune.ssl.default-dh-param 2048
+  # https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+  tune.ssl.default-dh-param 2048 # put DH parameters in certificate file against LOGJAM
+  ssl-default-bind-ciphers ECDH+AESGCM:ECDH+CHACHA20:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS:!RSA
+  ssl-default-bind-options no-sslv3 no-tls-tickets
+  ssl-default-server-ciphers ECDH+AESGCM:ECDH+CHACHA20:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS:!RSA
+  ssl-default-server-options no-sslv3 no-tls-tickets
 
 frontend http
   bind *:80
@@ -18,7 +22,7 @@ frontend https
   bind *:443 ssl crt /certs
   default_backend foodsoft
 
-  http-response set-header Strict-Transport-Security "max-age=16000000;"
+  http-response set-header Strict-Transport-Security max-age=15768000 # HSTS 6 months
   option forwardfor
   reqadd X-Forwarded-Proto:\ https
 

--- a/smtp/Dockerfile
+++ b/smtp/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.9
 
 RUN apk add --no-cache postfix rsyslog ca-certificates && \
     update-ca-certificates
@@ -8,5 +8,5 @@ COPY main.cf /etc/postfix/
 COPY docker-entrypoint.sh reload-postfix.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD /usr/lib/postfix/master & \
+CMD /usr/libexec/postfix/master & \
     /usr/sbin/rsyslogd -n

--- a/smtp/main.cf
+++ b/smtp/main.cf
@@ -5,7 +5,9 @@
 #   https://github.com/Mailu/Mailu/blob/master/core/postfix/
 #   https://github.com/hokstadconsulting/docker-postfix/
 #   https://www.howtoforge.com/community/threads/62955/
+#   https://blog.kruyt.org/postfix-and-tls-encryption/
 #
+compatibility_level = 2
 
 # Main domain and hostname
 mydomain = example.test        # overridden by postconf
@@ -46,7 +48,6 @@ alias_maps =
 #
 
 # General TLS configuration
-tls_high_cipherlist = EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA128-SHA:AES128-SHA
 tls_preempt_cipherlist = yes
 tls_ssl_options = NO_COMPRESSION
 smtpd_tls_CApath = /etc/ssl/certs/
@@ -54,13 +55,22 @@ smtpd_tls_CApath = /etc/ssl/certs/
 # Incoming TLS
 smtpd_tls_cert_file = # overridden by postconf
 smtpd_tls_key_file = $smtpd_tls_cert_file
+smtpd_tls_dh1024_param_file = $smtpd_tls_cert_file
 smtpd_tls_security_level = may
+smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1
+smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1
+smtpd_tls_mandatory_exclude_ciphers = MD5, DES, ADH, RC4, PSD, SRP, 3DES, eNULL, aNULL
+smtpd_tls_ciphers = high
+smtpd_tls_exclude_ciphers = MD5, DES, ADH, RC4, PSD, SRP, 3DES, eNULL, aNULL
 
 # Outgoing TLS is more flexible because 1. not all receiving servers will
 # support TLS, 2. not all will have and up-to-date TLS stack.
 smtp_tls_security_level = may
-smtp_tls_mandatory_protocols = !SSLv2,!SSLv3
-smtp_tls_protocols =!SSLv2,!SSLv3
+smtp_tls_protocols = !SSLv2, !SSLv3, !TLSv1
+smtp_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1
+smtp_tls_mandatory_exclude_ciphers = MD5, DES, ADH, RC4, PSD, SRP, 3DES, eNULL, aNULL
+smtp_tls_ciphers = high
+smtp_tls_exclude_ciphers = MD5, DES, ADH, RC4, PSD, SRP, 3DES, eNULL, aNULL
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
 #
@@ -80,6 +90,7 @@ smtpd_recipient_restrictions =
   reject_unknown_sender_domain,
   reject_unknown_recipient_domain,
   reject_unverified_recipient,
+  reject_unauth_destination,
   permit
 
 unverified_recipient_reject_reason = address lookup failure


### PR DESCRIPTION
Improvements after looking at the [hardenize report](https://www.hardenize.com/report/app.foodcoops.net/1555055281) in #30, testing with [testssl](https://testssl.sh/).
Depends on https://github.com/foodcoops/docker-certbot/pull/2.