### PR TITLE
Add latest Foodsoft version + Crowdin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,18 @@ services:
       - SMTP_SERVER_PORT=2525
       - SMTP_SERVER_HOST=0.0.0.0
 
+  foodsoft_latest:
+    build: foodsoft-latest
+    restart: always
+    environment:
+      - DATABASE_URL=mysql2://foodsoft_latest:${FOODSOFT_LATEST_DB_PASSWORD}@mariadb/foodsoft_latest?encoding=utf8mb4
+      - EMAIL_SENDER=noreply@${DOMAIN}
+      - HOSTNAME=app.${DOMAIN}
+      - QUEUE=foodsoft_latest_notifier
+      - REDIS_URL=redis://redis:6379
+      - SECRET_KEY_BASE=${FOODSOFT_LATEST_SECRET_KEY_BASE}
+      - SHAREDLISTS_DATABASE_URL=mysql2://foodsoft_latest:${FOODSOFT_LATEST_DB_PASSWORD}@mariadb/sharedlists?encoding=utf8mb4
+
   haproxy:
     build: haproxy
     restart: always

--- a/foodsoft-latest/Dockerfile
+++ b/foodsoft-latest/Dockerfile
@@ -1,0 +1,28 @@
+FROM foodcoops/foodsoft:latest
+
+USER root
+
+# update Crowdin in-context translations
+RUN if [ ! `which unzip` ]; then \
+      apt-get update && apt-get install --no-install-recommends -y unzip && \
+      rm -Rf /var/lib/apt/lists/* /var/cache/apt/*; \
+    fi
+RUN tmpdir=`mktemp -d` && \
+    wget -O /tmp/crowdin.zip https://crowdin.com/backend/download/project/foodsoft/ach.zip && \
+    unzip -q -d "$tmpdir" /tmp/crowdin.zip && \
+    tar -C "$tmpdir" -c -f - . | tar -x --strip-components=2 --no-overwrite-dir -f - && \
+    rm -Rf /tmp/crowdin.zip "$tmpdir"
+
+# add Crowdin Javascript for dummy language
+COPY pre-head.html.haml /tmp/
+RUN awk '$0 ~ "^\\s*= yield\\(:head\\)" && c == 0 {c = 1; system("cat /tmp/pre-head.html.haml") }; {print} ' \
+     app/views/layouts/_header.html.haml >/tmp/a && mv /tmp/a app/views/layouts/_header.html.haml && \
+     rm -f /tmp/pre-head.html.haml
+
+COPY docker-entrypoint2.sh ./
+
+USER nobody
+COPY app_config.yml ./config
+
+ENTRYPOINT ["./docker-entrypoint2.sh"]
+CMD ["./proc-start", "web"]

--- a/foodsoft-latest/app_config.yml
+++ b/foodsoft-latest/app_config.yml
@@ -1,0 +1,145 @@
+# Foodsoft configuration
+
+default: &defaults
+  # If you wanna serve more than one foodcoop with one installation
+  # Don't forget to setup databases for each foodcoop. See also MULTI_COOP_INSTALL
+  multi_coop_install: false
+
+  # If multi_coop_install you have to use a coop name, which you you wanna be selected by default
+  default_scope: 'latest'
+
+  # name of this foodcoop
+  name: FC Test
+  # foodcoop contact information (used for FAX messages)
+  contact:
+    street: Grüne Straße 103
+    zip_code: "10101"
+    city: Greencity
+    country: Foodland
+    email: foodsoft@foodcoop.test
+    phone:
+
+  # Homepage
+  homepage: https://foodcoops.github.io
+
+  # foodsoft documentation URL
+  help_url: https://github.com/foodcoops/foodsoft/wiki/Doku
+
+  # documentation URL for the apples&pears work system
+  applepear_url: https://github.com/foodcoops/foodsoft/wiki/%C3%84pfel-u.-Birnen
+
+  # custom foodsoft software URL (used in footer)
+  foodsoft_url: https://foodcoops.github.io
+
+  # Default language
+  #default_locale: en
+  # By default, foodsoft takes the language from the webbrowser/operating system.
+  # In case you really want foodsoft in a certain language by default, set this to true.
+  # When members are logged in, the language from their profile settings is still used.
+  #ignore_browser_locale: false
+  # Default timezone, e.g. UTC, Amsterdam, Berlin, etc.
+  #time_zone: Berlin
+  # Currency symbol, and whether to add a whitespace after the unit.
+  #currency_unit: €
+  #currency_space: true
+
+  # price markup in percent
+  price_markup: 2.0
+
+  # default vat percentage for new articles
+  tax_default: 7.0
+
+  # tolerance order option: If set to false, article tolerance values do not count
+  # for total article price as long as the order is not finished.
+  tolerance_is_costly: false
+
+  # Ordergroups, which have less than 75 apples should not be allowed to make new orders
+  # Comment out this option to activate this restriction
+  #stop_ordering_under: 75
+
+  # Comment out to completely hide apple points (be sure to comment stop_ordering_under)
+  #use_apple_points: false
+
+  # ordergroups can only order when their balance is higher than or equal to this
+  # not fully enforced right now, since the check is only client-side
+  #minimum_balance: 0
+
+  # how many days there are between two periodic tasks
+  #tasks_period_days: 7
+  # how many days upfront periodic tasks are created
+  #tasks_upfront_days: 49
+
+  # default order schedule, used to provide initial dates for new orders
+  # (recurring dates in ical format; no spaces!)
+  #order_schedule:
+  #  ends:
+  #    recurr: FREQ=WEEKLY;INTERVAL=2;BYDAY=MO
+  #    time: '9:00'
+  #  # reference point, this is generally the first pickup day; empty is often ok
+  #  #initial:
+
+  # When use_nick is enabled, there will be a nickname field in the user form,
+  # and the option to show a nickname instead of full name to foodcoop members.
+  # Members of a user's groups and administrators can still see full names.
+  use_nick: false
+
+  # Most plugins can be enabled/disabled here as well. Messages and wiki are enabled
+  # by default and need to be set to false to disable. Most other plugins needs to
+  # be enabled before they do anything.
+  #use_wiki: true
+  #use_messages: true
+
+  # Base font size for generated PDF documents
+  #pdf_font_size: 12
+  # Page size for generated PDF documents
+  #pdf_page_size: A4
+  # Some documents (like group and article PDFs) can include page breaks
+  # after each sublist.
+  #pdf_add_page_breaks: true
+  # Alternatively, this can be set for each document.
+  #pdf_add_page_breaks:
+  #  order_by_groups: true
+  #  order_by_articles: true
+
+
+  # Page footer (html allowed). Default is a Foodsoft footer. Set to `blank` for no footer.
+  #page_footer: <a href="http://www.foodcoop.test/">FC Test</a> is supported by <a href="http://www.hoster.test/">Hoster</a>.
+
+  # Custom CSS for the foodcoop
+  #custom_css: 'body { background-color: #fcffba; }'
+
+  # Uncomment to add tracking code for web statistics, e.g. for Piwik. (Added to bottom of page)
+  #webstats_tracking_code: |
+  #  <!-- Piwik -->
+  #  ......
+
+  # email address to be used as sender
+  email_sender: <%= ENV['EMAIL_SENDER'] %>
+
+  # domain to be used for reply emails
+  #reply_email_domain: reply.foodcoop.test
+
+  # If your foodcoop uses a mailing list instead of internal messaging system
+  #mailing_list: list@example.org
+  #mailing_list_subscribe: list-subscribe@example.org
+
+  # Config for the exception_notification plugin
+  notification:
+    error_recipients: <%= (ENV['ERROR_RECIPIENTS'] || '').split %>
+    sender_address: <%= "\\\"Foodsoft Error\\\" <#{ENV['EMAIL_SENDER']}>" %>
+    email_prefix: "[Foodsoft (latest)]"
+
+  # http config for this host to generate links in emails (uses environment config when not set)
+  protocol: https
+  host: <%= ENV['HOSTNAME'] %>
+  #port: 3000
+
+  # Access to sharedlists, the external article-database.
+  # This allows a foodcoop to subscribe to a selection of a supplier's full assortment,
+  # and makes it possible to share data with several foodcoops. Using this requires installing
+  # an additional application with a separate database.
+  shared_lists: <%= ENV['SHAREDLISTS_DATABASE_URL'] %>
+
+# don't remove this, required to run the app
+production:
+  <<: *defaults

--- a/foodsoft-latest/docker-entrypoint2.sh
+++ b/foodsoft-latest/docker-entrypoint2.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# run migrations, since we're running cutting-edge
+# an error will occur because the schema can't be written, but that's fine
+bundle exec rake db:migrate
+
+if [ -x ./docker-entrypoint.sh ]; then
+  exec ./docker-entrypoint.sh "$@"
+else
+  exec "$@"
+fi

--- a/foodsoft-latest/pre-head.html.haml
+++ b/foodsoft-latest/pre-head.html.haml
@@ -1,0 +1,9 @@
+    -# When the Crodwin dummy-locale is selected, load the Crowdin integration.
+    - if I18n.locale == :ach
+      :javascript
+        var _jipt = [
+          ['project', 'foodsoft'],
+          ['escape', function() { window.location.href = '/latest?locale=en'; }]
+        ];
+      = javascript_include_tag "//cdn.crowdin.com/jipt/jipt.js"
+

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -22,6 +22,7 @@ frontend https
   option forwardfor
   reqadd X-Forwarded-Proto:\ https
 
+  use_backend foodsoft_latest if { path_beg /latest }
   use_backend phpmyadmin if { path_beg /phpmyadmin }
   use_backend sharedlists if { path_beg /sharedlists }
   use_backend github if { hdr(host) -i foodcoops.net }
@@ -55,6 +56,9 @@ backend certbot
 
 backend foodsoft
   server foodsoft foodsoft:3000
+
+backend foodsoft_latest
+  server foodsoft_latest foodsoft_latest:3000
 
 backend github
   http-request set-header Host foodcoops.github.io


### PR DESCRIPTION
Implements #26, #32.

---
Adds latest Foodsoft docker image on `/latest`. Runs migrations when starting up.
![image](https://user-images.githubusercontent.com/503804/57133846-a5c0b200-6d93-11e9-9bfa-e69049806c10.png)


---
Adds [crowdin integration](https://support.crowdin.com/in-context-localization) when the dummy locale `ach` is selected.

![image](https://user-images.githubusercontent.com/503804/57133245-bbcd7300-6d91-11e9-8436-edcd08213dd3.png)
